### PR TITLE
Add `FoundationPublicationImage` entity and DTO for handling multiple…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>tech.rodal</groupId>
     <artifactId>resqpet-api</artifactId>
-    <version>1.0.13-SNAPSHOT</version>
+    <version>1.0.14-SNAPSHOT</version>
     <name>resqpet-api</name>
     <description>resqpet-api</description>
     <url/>

--- a/src/main/java/service/config/http/RestTemplateConfig.java
+++ b/src/main/java/service/config/http/RestTemplateConfig.java
@@ -10,7 +10,7 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(20_000);
         factory.setReadTimeout(20_000);
         return new RestTemplate(factory);

--- a/src/main/java/service/domain/dto/foundation/FoundationPublicationDTO.java
+++ b/src/main/java/service/domain/dto/foundation/FoundationPublicationDTO.java
@@ -10,6 +10,7 @@ import service.domain.dto.BaseDTO;
 import service.domain.entity.foundation.FoundationPublication;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Objects;
 
 @Data
@@ -25,6 +26,7 @@ public class FoundationPublicationDTO extends BaseDTO {
     private String content;
     private String imageUrl;
     private LocalDate eventDate;
+    private List<FoundationPublicationImageDTO> images;
 
     public FoundationPublicationDTO(FoundationPublication publication) {
         super(publication);
@@ -32,7 +34,7 @@ public class FoundationPublicationDTO extends BaseDTO {
             this.foundation = new FoundationDTO(publication.getFoundation());
             this.title = publication.getTitle();
             this.content = publication.getContent();
-            this.imageUrl = publication.getImageUrl();
+            this.images = publication.getFoundationPublicationImages().stream().map(FoundationPublicationImageDTO::new).toList();
             this.eventDate = publication.getEventDate();
         }
     }

--- a/src/main/java/service/domain/dto/foundation/FoundationPublicationImageDTO.java
+++ b/src/main/java/service/domain/dto/foundation/FoundationPublicationImageDTO.java
@@ -1,0 +1,31 @@
+package service.domain.dto.foundation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import service.domain.dto.BaseDTO;
+import service.domain.entity.foundation.FoundationPublicationImage;
+
+import java.util.Objects;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FoundationPublicationImageDTO extends BaseDTO {
+
+    private String imageUrl;
+
+    public FoundationPublicationImageDTO(FoundationPublicationImage image) {
+        super(image);
+        if (Objects.nonNull(image)) {
+            this.imageUrl = image.getImageUrl();
+        }
+    }
+
+}

--- a/src/main/java/service/domain/entity/foundation/FoundationPublicationImage.java
+++ b/src/main/java/service/domain/entity/foundation/FoundationPublicationImage.java
@@ -5,9 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -19,9 +17,6 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import service.domain.entity.BaseEntity;
 
-import java.time.LocalDate;
-import java.util.List;
-
 @Getter
 @Setter
 @Entity
@@ -29,30 +24,18 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Table(name = "foundation_publication", schema = "RESQPET")
-public class FoundationPublication extends BaseEntity {
+@Table(name = "foundation_publication_image", schema = "RESQPET")
+public class FoundationPublicationImage extends BaseEntity {
 
     @NotNull
     @EqualsAndHashCode.Exclude
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "FOUNDATION_ID", nullable = false)
-    private Foundation foundation;
+    @JoinColumn(name = "PUBLICATION_ID", nullable = false)
+    private FoundationPublication publication;
 
+    @NotNull
     @Size(max = 255)
-    @NotNull
-    @Column(name = "TITLE", nullable = false)
-    private String title;
-
-    @NotNull
-    @Lob
-    @Column(name = "CONTENT", nullable = false)
-    private String content;
-
-    @Column(name = "EVENT_DATE")
-    private LocalDate eventDate;
-
-    @EqualsAndHashCode.Exclude
-    @OneToMany(mappedBy = "publication")
-    private List<FoundationPublicationImage> foundationPublicationImages;
+    @Column(name = "IMAGE_URL", nullable = false)
+    private String imageUrl;
 
 }


### PR DESCRIPTION
… images in foundation publications

- Introduce `FoundationPublicationImage` entity and `FoundationPublicationImageDTO` for managing publication images.
- Update `FoundationPublication` to support multiple images with a one-to-many relationship.
- Modify `FoundationPublicationDTO` to include a list of `FoundationPublicationImageDTO`.
- Refactor code to use `FoundationPublicationImageDTO` mappings.
- Bump project version to `1.0.14-SNAPSHOT`.