### PR TITLE
Introduce support for foundation publication comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>tech.rodal</groupId>
     <artifactId>resqpet-api</artifactId>
-    <version>1.0.16-SNAPSHOT</version>
+    <version>1.0.17-SNAPSHOT</version>
     <name>resqpet-api</name>
     <description>resqpet-api</description>
     <url/>

--- a/src/main/java/service/domain/dto/foundation/BaseFoundationPublicationCommentDTO.java
+++ b/src/main/java/service/domain/dto/foundation/BaseFoundationPublicationCommentDTO.java
@@ -1,0 +1,34 @@
+package service.domain.dto.foundation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import service.domain.dto.BaseDTO;
+import service.domain.dto.users.BaseUserDTO;
+import service.domain.entity.foundation.FoundationPublicationComment;
+
+import java.util.Objects;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BaseFoundationPublicationCommentDTO extends BaseDTO {
+
+    private BaseUserDTO user;
+    private String content;
+
+    public BaseFoundationPublicationCommentDTO(FoundationPublicationComment comment) {
+        super(comment);
+        if (Objects.nonNull(comment)) {
+            this.user = new BaseUserDTO(comment.getUser());
+            this.content = comment.getContent();
+        }
+    }
+
+}

--- a/src/main/java/service/domain/dto/foundation/FoundationPublicationCommentDTO.java
+++ b/src/main/java/service/domain/dto/foundation/FoundationPublicationCommentDTO.java
@@ -1,0 +1,31 @@
+package service.domain.dto.foundation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import service.domain.entity.foundation.FoundationPublicationComment;
+
+import java.util.List;
+import java.util.Objects;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FoundationPublicationCommentDTO extends BaseFoundationPublicationCommentDTO {
+
+    private List<BaseFoundationPublicationCommentDTO> replies;
+
+    public FoundationPublicationCommentDTO(FoundationPublicationComment comment) {
+        super(comment);
+        if (Objects.nonNull(comment)) {
+            this.replies = comment.getReplies().stream().map(BaseFoundationPublicationCommentDTO::new).toList();
+        }
+    }
+
+}

--- a/src/main/java/service/domain/dto/foundation/FoundationPublicationDTO.java
+++ b/src/main/java/service/domain/dto/foundation/FoundationPublicationDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import service.domain.dto.BaseDTO;
 import service.domain.entity.foundation.FoundationPublication;
+import service.domain.entity.foundation.FoundationPublicationComment;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -27,6 +28,7 @@ public class FoundationPublicationDTO extends BaseDTO {
     private String imageUrl;
     private LocalDate eventDate;
     private List<FoundationPublicationImageDTO> images;
+    private List<FoundationPublicationCommentDTO> comments;
 
     public FoundationPublicationDTO(FoundationPublication publication) {
         super(publication);
@@ -34,8 +36,9 @@ public class FoundationPublicationDTO extends BaseDTO {
             this.foundation = new BaseFoundationDTO(publication.getFoundation());
             this.title = publication.getTitle();
             this.content = publication.getContent();
-            this.images = publication.getFoundationPublicationImages().stream().map(FoundationPublicationImageDTO::new).toList();
             this.eventDate = publication.getEventDate();
+            this.images = publication.getImages().stream().map(FoundationPublicationImageDTO::new).toList();
+            this.comments = publication.getComments().stream().map(FoundationPublicationCommentDTO::new).toList();
         }
     }
 

--- a/src/main/java/service/domain/entity/foundation/FoundationPublicationComment.java
+++ b/src/main/java/service/domain/entity/foundation/FoundationPublicationComment.java
@@ -1,6 +1,7 @@
 package service.domain.entity.foundation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,8 +9,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,8 +16,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import service.domain.entity.BaseEntity;
+import service.domain.entity.user.User;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -28,32 +27,28 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Table(name = "foundation_publication", schema = "RESQPET")
-public class FoundationPublication extends BaseEntity {
+@Table(name = "foundation_publication_comment", schema = "RESQPET")
+public class FoundationPublicationComment extends BaseEntity {
 
-    @NotNull
     @EqualsAndHashCode.Exclude
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "FOUNDATION_ID", nullable = false)
-    private Foundation foundation;
+    @JoinColumn(name = "PUBLICATION_ID", nullable = false)
+    private FoundationPublication publication;
 
-    @Size(max = 255)
-    @NotNull
-    @Column(name = "TITLE", nullable = false)
-    private String title;
+    @EqualsAndHashCode.Exclude
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "USER_ID", nullable = false)
+    private User user;
 
-    @NotNull
     @Column(name = "CONTENT", nullable = false)
     private String content;
 
-    @Column(name = "EVENT_DATE")
-    private LocalDate eventDate;
-
     @EqualsAndHashCode.Exclude
-    @OneToMany(mappedBy = "publication")
-    private List<FoundationPublicationImage> images;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PARENT_COMMENT_ID")
+    private FoundationPublicationComment parentComment;
 
-    @OneToMany(mappedBy = "publication")
-    private List<FoundationPublicationComment> comments;
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FoundationPublicationComment> replies;
 
 }

--- a/src/main/java/service/domain/repository/foundation/FoundationPublicationCommentRepository.java
+++ b/src/main/java/service/domain/repository/foundation/FoundationPublicationCommentRepository.java
@@ -1,0 +1,7 @@
+package service.domain.repository.foundation;
+
+import service.domain.entity.foundation.FoundationPublicationComment;
+import service.domain.repository.BaseRepository;
+
+public interface FoundationPublicationCommentRepository extends BaseRepository<FoundationPublicationComment> {
+}

--- a/src/main/java/service/domain/request/foundation/CommentRequest.java
+++ b/src/main/java/service/domain/request/foundation/CommentRequest.java
@@ -1,0 +1,17 @@
+package service.domain.request.foundation;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CommentRequest {
+
+    @NotNull(message = "The publication id is required")
+    private Long publicationId;
+
+    @NotNull(message = "The content is required")
+    private String content;
+
+    private Long parentCommentId;
+
+}

--- a/src/main/java/service/resources/foundation/FoundationPublicationCommentResource.java
+++ b/src/main/java/service/resources/foundation/FoundationPublicationCommentResource.java
@@ -1,0 +1,27 @@
+package service.resources.foundation;
+
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import service.aspect.Current;
+import service.domain.dto.foundation.BaseFoundationPublicationCommentDTO;
+import service.domain.entity.user.User;
+import service.domain.request.foundation.CommentRequest;
+import service.services.foundation.publication.comment.FoundationPublicationCommentService;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/foundations/publications/comments")
+public class FoundationPublicationCommentResource {
+
+    private final FoundationPublicationCommentService service;
+
+    @PostMapping
+    public ResponseEntity<BaseFoundationPublicationCommentDTO> create(@Valid @RequestBody CommentRequest request, @Current User user) {
+        return ResponseEntity.ok(new BaseFoundationPublicationCommentDTO(this.service.create(request, user)));
+    }
+}

--- a/src/main/java/service/services/foundation/publication/comment/DefaultFoundationPublicationCommentService.java
+++ b/src/main/java/service/services/foundation/publication/comment/DefaultFoundationPublicationCommentService.java
@@ -1,0 +1,53 @@
+package service.services.foundation.publication.comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import service.domain.entity.foundation.FoundationPublication;
+import service.domain.entity.foundation.FoundationPublicationComment;
+import service.domain.entity.user.User;
+import service.domain.repository.foundation.FoundationPublicationCommentRepository;
+import service.domain.request.foundation.CommentRequest;
+import service.services.DefaultBaseService;
+import service.services.foundation.publication.FoundationPublicationService;
+
+import java.util.Objects;
+
+@Getter
+@Service
+@AllArgsConstructor
+public class DefaultFoundationPublicationCommentService extends DefaultBaseService<FoundationPublicationComment> implements FoundationPublicationCommentService {
+
+    private final FoundationPublicationCommentRepository repository;
+    private final FoundationPublicationService publicationService;
+
+    /**
+     * Creates a new FoundationPublicationComment entity based on the provided request and user.
+     *
+     * @param request the CommentRequest object containing the details of the comment to be created.
+     *                It includes the publication ID, the content of the comment,
+     *                and optionally the parent comment ID if it's a reply.
+     * @param user    the User object representing the author of the comment.
+     * @return the created FoundationPublicationComment entity.
+     */
+    @Override
+    @Transactional
+    public FoundationPublicationComment create(CommentRequest request, User user) {
+        FoundationPublication publication = this.publicationService.findById(request.getPublicationId());
+        FoundationPublicationComment parentComment = null;
+
+        if (Objects.nonNull(request.getParentCommentId())) {
+            parentComment = this.findById(request.getParentCommentId());
+            publication = null;
+        }
+
+        final FoundationPublicationComment comment = FoundationPublicationComment.builder()
+                .content(request.getContent())
+                .parentComment(parentComment)
+                .publication(publication)
+                .user(user)
+                .build();
+        return this.create(comment);
+    }
+}

--- a/src/main/java/service/services/foundation/publication/comment/FoundationPublicationCommentService.java
+++ b/src/main/java/service/services/foundation/publication/comment/FoundationPublicationCommentService.java
@@ -1,0 +1,12 @@
+package service.services.foundation.publication.comment;
+
+import service.domain.entity.foundation.FoundationPublicationComment;
+import service.domain.entity.user.User;
+import service.domain.request.foundation.CommentRequest;
+import service.services.BaseService;
+
+public interface FoundationPublicationCommentService extends BaseService<FoundationPublicationComment> {
+
+    FoundationPublicationComment create(CommentRequest request, User user);
+
+}


### PR DESCRIPTION
- Add `FoundationPublicationComment` entity and DTOs (`BaseFoundationPublicationCommentDTO`, `FoundationPublicationCommentDTO`) for comment handling.
- Implement APIs for adding comments to foundation publications (`FoundationPublicationCommentResource`).
- Design `DefaultFoundationPublicationCommentService` for managing comment creation and associations.
- Update `FoundationPublication` entity and DTO to include comments.
- Modify project version to `1.0.17-SNAPSHOT`.